### PR TITLE
adding asynchronous method createRotatedImageAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,42 +23,43 @@ yarn add exif-auto-rotate
 ```javascript
 import Rotator from 'exif-auto-rotate';
 
-Rotator.imageFileRotator(
-    file, //is the file of the new image that can now be uploaded.
-    outputType  // is the output type of the new image.
-    responseUriFunc,  // is the callBack function of the new image URI
-    );
-```
-## Example 
-First, wrap this resizer:
-```javascript
-const autoRotateFile = (file) => new Promise(resolve => {
-    Rotator.imageFileRotator(file, 'base64',
-    uri => {
-      resolve(uri);
-    }
-    );
-});
-```
+// sync
+Rotator.createRotatedImage(
+  file, // the file of the new image that can now be uploaded.
+  outputType  // the output type of the new image.
+  responseUriFunc,  // the callBack function of the new image URI
+);
 
-And then use it in your async function:
+// async
+Rotator.createRotatedImageAsync(
+  file, // the file of the new image that can now be uploaded.
+  outputType  // the output type of the new image.
+);
+```
+## Examples 
+
 ```javascript
-const onChange = async (event) => {
-  try {
-    const file = event.target.files[0];
-    const image = await autoRotateFile(file);
-    console.log(image);
-  } catch(err) {
-      console.log(err);
-    }
+// sync
+Rotator.createRotatedImage(file, 'base64', (uri) => {
+  console.log(uri);
+});
+
+// async
+try {
+  const file = event.target.files[0];
+  const uri = await Rotator.createRotatedImageAsync(file, 'base64');
+  console.log(uri);
+} catch(err) {
+  console.log(err);
 }
+
 ```
 
 Option | Description | Type | Required
 ------ | ----------- | ---- | --------
 `file` | Path of image file | `object` | Yes
 `outputType` | Can be either base64 or blob.(Default type is base64) | `string` | No
-`responseUriFunc` | Callback function of URI. Returns URI of rotated image's base64 or Blob format. ex: `uri => {console.log(uri)});` | `function` | Yes
+`responseUriFunc` | Callback function of URI. Returns URI of rotated image's base64 or Blob format. ex: `uri => {console.log(uri)});` | `function` | Yes (sync only)
 
 
 ## License

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,11 @@
 * @author Onur Zorluer
 *
 */
+
+function throwError(msg) {
+    throw Error(msg);
+}
+
 class Rotator {
 
     static rotateImage(image, srcOrientation) {
@@ -95,13 +100,13 @@ class Rotator {
         reader.readAsArrayBuffer(file.slice(0, 64 * 1024));
       };
 
-    static createRotatedImage(file, outputType = 'base64', responseUriFunc) {
+    static createRotatedImage(file, outputType = 'base64', responseUriFunc, errorHandler = throwError) {
         var blob = null
         var rotatedDataUrl = null
         const reader = new FileReader();
         if(file) {
             if(file.type && !file.type.includes("image")) {
-                throw Error("File Is NOT Image!");
+                errorHandler("File Is NOT Image!");
               } else {           
                 reader.readAsDataURL(file);
                 reader.onload = () => {
@@ -114,9 +119,9 @@ class Rotator {
                     }; 
                 function rotatorFunction(imageOrientation, image) {
                     if(imageOrientation == -2) {
-                        throw Error("Image Is NOT JPEG!");
+                        errorHandler("Image Is NOT JPEG!");
                     } else if(imageOrientation == -1) {
-                        throw Error("Not Defined!");
+                        errorHandler("Not Defined!");
                     }
                     rotatedDataUrl = Rotator.rotateImage(image, imageOrientation);
                     blob = Rotator.b64toBlob(rotatedDataUrl);
@@ -127,16 +132,26 @@ class Rotator {
                     }   
                 };
                 reader.onerror = error => {
-                    throw Error(error);
+                    errorHandler(error);
                 }; 
             }
         } else {
-            throw Error("File Not Found!");
+            errorHandler("File Not Found!");
           }
+    }
+
+    static createRotatedImageAsync(file, outputType = 'base64') {
+        return new Promise((resolve, reject) => {
+            Rotator.createRotatedImage(file, outputType, resolve, reject);
+        });
     }
 }   
 
-export default { createRotatedImage: (file, outputType, responseUriFunc) => {
+export default {
+    createRotatedImage: (file, outputType, responseUriFunc) => {
         return Rotator.createRotatedImage(file, outputType, responseUriFunc)
-    } 
+    },
+    createRotatedImageAsync: (file, outputType) => {
+        return Rotator.createRotatedImageAsync(file, outputType);
+    }
 }


### PR DESCRIPTION
### Context
It isn't possible to handle errors for the default `createRotatedImage` function. When an error is thrown during image rotation, they are thrown in a different context making them impossible to catch.

This change adds an async version of this function. It wraps the `createRotatedImage` in a promise, and allows the consumer to properly deal with the resolve and reject conditions.

### Changes
*  adding `createRotatedImageAsync` function
* update README with the correct function name
* update README with `createRotatedImageAsync` usage
